### PR TITLE
convert from float to int to handle error invalid literal for int() with base 10: '54.5'

### DIFF
--- a/imgann/operators/pascalvoc.py
+++ b/imgann/operators/pascalvoc.py
@@ -163,10 +163,10 @@ class PascalVOC(IOperator, ABC):
         try:
             label = self.__tagFilter(obj.find('name').text)
             bndbox = obj.find('bndbox')
-            xmin = int(bndbox.find('xmin').text)
-            ymin = int(bndbox.find('ymin').text)
-            xmax = int(bndbox.find('xmax').text)
-            ymax = int(bndbox.find('ymax').text)
+            xmin = int(float(bndbox.find('xmin').text))
+            ymin = int(float(bndbox.find('ymin').text))
+            xmax = int(float(bndbox.find('xmax').text))
+            ymax = int(float(bndbox.find('ymax').text))
             ann = [xmin, ymin, xmax, ymax, label]
             return ann
         except Exception as error:

--- a/imgann/operators/pascalvoc.py
+++ b/imgann/operators/pascalvoc.py
@@ -163,10 +163,10 @@ class PascalVOC(IOperator, ABC):
         try:
             label = self.__tagFilter(obj.find('name').text)
             bndbox = obj.find('bndbox')
-            xmin = int(float(bndbox.find('xmin').text))
-            ymin = int(float(bndbox.find('ymin').text))
-            xmax = int(float(bndbox.find('xmax').text))
-            ymax = int(float(bndbox.find('ymax').text))
+            xmin = float(bndbox.find('xmin').text)
+            ymin = float(bndbox.find('ymin').text)
+            xmax = float(bndbox.find('xmax').text)
+            ymax = float(bndbox.find('ymax').text)
             ann = [xmin, ymin, xmax, ymax, label]
             return ann
         except Exception as error:


### PR DESCRIPTION
Since you were expecting ymin, ymin to be integers it happened in my case were floats and I was getting error `ValueError: invalid literal for int() with base 10: '54.5'
` which is fixed 