### PR TITLE
Bug fix: Handling file names with multiple .(period symbols)

### DIFF
--- a/imgann/convert.py
+++ b/imgann/convert.py
@@ -69,7 +69,7 @@ class Convertor:
         voc_obj.set_annotations(ann)
         voc_obj.set_classes(cls)
         for xml, name in voc_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.xml'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.xml'
             voc_obj.archive(file_dir, xml)
 
     @staticmethod
@@ -98,7 +98,7 @@ class Convertor:
         yolo_obj.set_annotations(ann)
         yolo_obj.set_classes(cls)
         for data, name in yolo_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.txt'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.txt'
             yolo_obj.archive(file_dir, data)
 
     @staticmethod
@@ -150,7 +150,7 @@ class Convertor:
         voc_obj.set_annotations(ann)
         voc_obj.set_classes(cls)
         for xml, name in voc_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.xml'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.xml'
             voc_obj.archive(file_dir, xml)
 
     @staticmethod
@@ -177,7 +177,7 @@ class Convertor:
         yolo_obj.set_annotations(ann)
         yolo_obj.set_classes(cls)
         for data, name in yolo_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.txt'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.txt'
             yolo_obj.archive(file_dir, data)
 
     @staticmethod
@@ -255,7 +255,7 @@ class Convertor:
         yolo_obj.set_annotations(ann)
         yolo_obj.set_classes(cls)
         for data, name in yolo_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.txt'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.txt'
             yolo_obj.archive(file_dir, data)
 
     @staticmethod
@@ -324,7 +324,7 @@ class Convertor:
         voc_obj.set_annotations(ann)
         voc_obj.set_classes(cls)
         for xml, name in voc_obj.translate():
-            file_dir = save_dir + '/' + name.split('.')[0]+'.xml'
+            file_dir = save_dir + '/' + name.rsplit('.', 1)[0]+'.xml'
             voc_obj.archive(file_dir, xml)
 
     @staticmethod


### PR DESCRIPTION
## Bug
Let's say we are having multiple files with names (with their associated labels in Pascal VOC format):
- 002020.jpg
- 002021.jpg
- 2021-01-26_18.14.00.mp4_760.jpg
- 2021-01-26_18.14.00.mp4_874.jpg

When we try to convert from Pascal VOC to YOLO format, we get the following conversion result in YOLO format:
- 002020.txt
- 002021.txt
- 2021-01-26_18.txt

Here we can see some labels are missing.

## Fix
Instead of using `split` to extract the file name, we can use `rsplit` to get the filename correctly.

**For eg.**
```python
name = '2021-01-26_18.14.00.mp4_874.jpg'
name.split('.')[0]    # '2021-01-26_18'
name.rsplit('.', 1)[0]    # '2021-01-26_18.14.00.mp4_874'
```